### PR TITLE
Run Tailwind CSS from installed plugin directory

### DIFF
--- a/pelican/plugins/tailwindcss/tailwindcss.py
+++ b/pelican/plugins/tailwindcss/tailwindcss.py
@@ -65,9 +65,8 @@ def generate_css(po):
     input_output = f"-i {input_file_path} -o {output_file_path}"
     print(f"{utils.LOG_PREFIX} Build css ({output_file_path})")
 
-    subprocess.run(
+    commands.run_in_plugin(
         f"npx tailwindcss -c {twconfig_file_path} {input_output}",
-        shell=True,
     )
 
 


### PR DESCRIPTION
Recently the following error began to appear:

    npm error could not determine executable to run

Three possibly-relevant lines from the NPM verbose log are:

```
16 verbose pkgid tailwindcss@4.0.7
17 error could not determine executable to run
18 verbose cwd /Users/myuser/Documents/pelican-test-site
```

The test site project and plugin are configured for Tailwind CSS 3.x, so it is not at all clear how and why Tailwind CSS 4.0.7 appears in the verbose log, but that is the mostly likely culprit given that this error has never occurred before.

My current workaround is to ensure that Tailwind CSS is invoked from the installed plugin directory instead of the Pelican site project root.